### PR TITLE
Fix function `dwim-map`, add missing dependency, fix whitespace

### DIFF
--- a/ch6-lists.lisp
+++ b/ch6-lists.lisp
@@ -2,7 +2,12 @@
 
 (defun dwim-map (fn seq &rest seqs)
   "A thin wrapper over MAP that uses the type of the first SEQ for the result."
-  (apply 'map (type-of seq) fn seqs))
+  (apply 'map (type-of seq) fn (cons seq seqs)))
+
+(deftest dwim-map ()
+  (should be equal '(5 7 9)
+          (dwim-map '+ '(1 2 3)
+                       '(4 5 6))))
 
 (defun simple-mapcar-v1 (fn list)
   (let ((rez (list)))
@@ -32,7 +37,7 @@
 (defun our-cons2 (data list)
   (when (null list) (setf list (make-our-own-list)))
   (let ((new-head (make-list-cell2
-                   :data data 
+                   :data data
                    :next (rtl:? list 'head))))
     (when (rtl:? list 'head)
       (setf (rtl:? list 'head 'prev) new-head))

--- a/ch7-kvs.lisp
+++ b/ch7-kvs.lisp
@@ -18,6 +18,21 @@
   (should be equal '((:bar . :baz))
           (alist-del :foo (list (cons :foo 42) (cons :bar :baz)))))
 
+(defmethod generic-elt ((obj vector) key &rest keys)
+  (declare (ignore keys))
+  ;; Python-like handling of negative indices as offsets from the end
+  (when (minusp key) (setf key (+ (length obj) key)))
+  (aref obj key))
+
+(deftest generic-elt-vector ()
+  (let ((vec #(1 2 3)))
+    (should be equal 1 (generic-elt vec 0))
+    (should be equal 2 (generic-elt vec 1))
+    (should be equal 3 (generic-elt vec 2))
+    (should be equal (generic-elt vec 0) (generic-elt vec -3))
+    (should be equal (generic-elt vec 1) (generic-elt vec -2))
+    (should be equal (generic-elt vec 2) (generic-elt vec -1))))
+
 (defun start-memoizing (fn)
   (stop-memoizing fn)
   (setf (symbol-function fn)

--- a/errata.md
+++ b/errata.md
@@ -1,8 +1,25 @@
 # Errata for *Programming Algorithms in Lisp*
 
-On **page xx** [Summary of error]:
- 
-Details of error here. Highlight key pieces in **bold**.
+On **page 79** Function `dwim-map` leaves the first sequence out. It should be:
+
+```
+(defun dwim-map (fn seq &rest seqs)
+  "A thin wrapper over MAP that uses the type of the first SEQ for the result."
+  (apply 'map (type-of seq) fn (cons seq seqs)))
+```
+
+***
+
+On **page 109** Method `generic-elt` for vectors calculated index wrong for
+negative keys. It should be:
+
+```
+(defmethod generic-elt ((obj vector) key &rest keys)
+  (declare (ignore keys))
+  ;; Python-like handling of negative indices as offsets from the end
+  (when (minusp key) (setf key (+ (length obj) key)))
+  (aref obj key))
+```
 
 ***
 

--- a/progalgs.asd
+++ b/progalgs.asd
@@ -1,11 +1,11 @@
 (in-package #:asdf-user)
 
 (defsystem #:progalgs
-  :version "1.1"
+  :version "1.2"
   :description "Code for the book 'Programming Algorithms in Lisp'"
   :author "Vsevolod Dyomkin <vseloved@gmail.com>"
   :maintainer "Vsevolod Dyomkin <vseloved@gmail.com>"
-  :depends-on (#:rutils #:eager-future2 #:sha1 #:lparallel #:should-test)
+  :depends-on (#:rutils #:eager-future2 #:sha1 #:lparallel #:should-test #:flexi-streams)
   :serial t
   :components ((:file "package")
                (:file "ch1-complexity")


### PR DESCRIPTION
 * Fix function `dwim-map` in chapter 6. It left the first
   sequence out from the mapping. Add also new unit test
   for this function. It detects the issue and prevents
   regression.

 * Add missing dependency to the system definition. It made
   the system loading to fail on `ch14-compression.lisp`
   that uses flexi-streams.

 * Remove one unnecessary space from end of line.